### PR TITLE
Update version and PyPI hash to v0.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kikuchipy" %}
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2b03a20deb396bc3510bcc2d564422e82e1d552848f8f07e1b9a9b4c95189af6
+  sha256: 995c38fbd18c9f22da8941174cc74d7d702f37b391730c3e4093add952ba6591
 
 build:
   noarch: python
@@ -25,10 +25,9 @@ requirements:
     - h5py
     - matplotlib
     - numpy >=1.17
-    - pyxem >=0.10
     - scikit-image >=0.16,<0.17
     - scikit-learn
-    - scipy >=1.4
+    - scipy
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
   host:
@@ -34,6 +34,13 @@ test:
     - pytest >=5.3.2
   imports:
     - kikuchipy
+    - kikuchipy.filters
+    - kikuchipy.generators
+    - kikuchipy.io
+    - kikuchipy.pattern
+    - kikuchipy.pattern.chunk
+    - kikuchipy.signals
+    - kikuchipy.release
   commands:
     - pytest --pyargs kikuchipy
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

A dependency conflict was introduced with the HyperSpy package in v0.2.0 (https://github.com/kikuchipy/kikuchipy/issues/179). This patch release should fix this.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/kikuchipy/kikuchipy/issues/179.

<!--
Please add any other relevant info below:
-->
